### PR TITLE
Debug1,2,3,6, and an additional issue

### DIFF
--- a/js/model/EnergySkateParkBasicsModel.js
+++ b/js/model/EnergySkateParkBasicsModel.js
@@ -1105,7 +1105,7 @@ define( function( require ) {
 
         // Make sure the new track doesn't go underground after a control point is deleted, see #174
         newTrack.bumpAboveGround();
-        newTrack.bumpAsideWindow();
+
         this.tracks.add( newTrack );
       }
 
@@ -1226,7 +1226,6 @@ define( function( require ) {
       // When tracks are joined, bump the new track above ground so the y value (and potential energy) cannot go negative,
       // and so it won't make the "return skater" button get bigger, see #158
       newTrack.bumpAboveGround();
-      newTrack.bumpAsideWindow();
       this.tracks.add( newTrack );
 
       // Move skater to new track if he was on the old track, by searching for the best fit point on the new track

--- a/js/model/SimulationModel.js
+++ b/js/model/SimulationModel.js
@@ -621,7 +621,6 @@ define( function( require ) {
       // Friction force should not exceed sum of other forces (in the direction of motion), otherwise the friction could
       // start a stopped object moving. Hence we check to see if the object is already stopped and don't add friction
       // in that case
-
       if ( this.friction === 0 || skaterState.getSpeed() < 1E-2 ) {
         return 0;
       }
@@ -1178,25 +1177,15 @@ define( function( require ) {
     // Find whatever track is connected to the specified track and join them together to a new track
     joinTracks: function( track ) {
     var flag=0;
-
       var connectedPoint = track.getSnapTarget();
       var physicalTracks = this.getPhysicalTracks();
       var otherTrack;
       for ( var i = 0; i < physicalTracks.length; i++ ) {
          otherTrack = physicalTracks[i];
         if ( otherTrack.containsControlPoint( connectedPoint ) ) {
-
-          //Zhilin
-          //if they are not overlap
-          // if((track.controlPoints[0].sourcePosition.x > otherTrack.controlPoints[0].sourcePosition.x) && 
-          //   (track.controlPoints[track.controlPoints.length - 1].sourcePosition.x < otherTrack.controlPoints[otherTrack.controlPoints.length - 1].sourcePosition.x)){
-          //   continue;
-          // }
-
           this.joinTrackToTrack( track, otherTrack );
           flag=1;
           break;
-
         }
       }
       if(flag==1) {
@@ -1259,7 +1248,8 @@ define( function( require ) {
         newTrack.bumpAboveGround();
 
         //Zhilin
-        newTrack.bumpAsideWindow();
+        newTrack.bumpAsideLeftWindow();
+        newTrack.bumpAsideRightWindow();
 
         this.tracks.add( newTrack );
       }
@@ -1350,8 +1340,6 @@ define( function( require ) {
 	points.push( b.controlPoints[i].copyWithSnap() );
       };
 
-      
-
       // Only include one copy of the snapped point
       // Forward Forward
       if ( a.controlPoints[a.controlPoints.length - 1].snapTarget === b.controlPoints[0] ) {
@@ -1399,7 +1387,9 @@ define( function( require ) {
       // When tracks are joined, bump the new track above ground so the y value (and potential energy) cannot go negative,
       // and so it won't make the "return skater" button get bigger, see #158
       newTrack.bumpAboveGround();
-      newTrack.bumpAsideWindow();
+      //Zhilin
+      newTrack.bumpAsideLeftWindow();
+      newTrack.bumpAsideRightWindow();
       this.tracks.add( newTrack );
 
       // Move skater to new track if he was on the old track, by searching for the best fit point on the new track

--- a/js/model/Track.js
+++ b/js/model/Track.js
@@ -574,7 +574,7 @@ define( function( require ) {
         var ptX = SplineEvaluation.atNumber( this.xSpline, a );
         var ptY = SplineEvaluation.atNumber( this.ySpline, a );
 
-        var dx = prexf - ptX;
+        var dx = prevX - ptX;
         var dy = prevY - ptY;
 
         sum += Math.sqrt( dx * dx + dy * dy );
@@ -702,7 +702,9 @@ define( function( require ) {
         this.translate( 0, -lowestY );
       }
     },
+
     //////below Zhilin changes
+    //////This two new methods ensure the track not going out of the left limit of window
     getLowestX: function() {
       if ( !this.ySearchPoints ) {
         this.xSearchPoints = SplineEvaluation.atArray( this.xSpline, this.searchLinSpace );
@@ -740,16 +742,62 @@ define( function( require ) {
       return min;
     },
 
-    // If any part of the track is below ground, move the whole track up so it rests at y=0 at its minimum, see #71
-    // Called when user releases track or a control point after dragging
-    bumpAsideWindow: function() {
+    bumpAsideLeftWindow: function() {
       var lowestX = this.getLowestX();
       if ( lowestX < -9.5 ) {
         this.translate(-9.5-lowestX, 0 );
       }
     },
 
+    getHighestX: function() {
+      if ( !this.ySearchPoints ) {
+        this.xSearchPoints = SplineEvaluation.atArray( this.xSpline, this.searchLinSpace );
+        this.ySearchPoints = SplineEvaluation.atArray( this.ySpline, this.searchLinSpace );
+      }
+
+      var max = Number.NEGATIVE_INFINITY;
+      var maxIndex = -1;
+      var x;
+      for ( var i = 0; i < this.xSearchPoints.length; i++ ) {
+        x = this.xSearchPoints[i];
+        if ( x > max ) {
+          max = x;
+          maxIndex = i;
+        }
+      }
+
+      // Increase resolution in the neighborhood of y
+      var foundU = this.searchLinSpace[maxIndex];
+
+      var minBound = foundU - this.distanceBetweenSamplePoints;
+      var maxBound = foundU + this.distanceBetweenSamplePoints;
+
+      var smallerSpace = numeric.linspace( minBound, maxBound, 200 );
+      var refinedSearchPoints = SplineEvaluation.atArray( this.xSpline, smallerSpace );
+
+      max = Number.NEGATIVE_INFINITY;
+      for ( i = 0; i < refinedSearchPoints.length; i++ ) {
+        x = refinedSearchPoints[i];
+        if ( x > max ) {
+          max = x;
+        }
+      }
+
+      return max;
+    },
+
+    //ensure the track won't get beyond the right limit
+    bumpAsideRightWindow: function() {
+      var highestX = this.getHighestX();
+      if ( highestX > 10 ) {
+        this.translate( -2, 0 );
+      }
+    },
+
     /////////above Zhilin change
+
+
+
 
     /**
      * Smooth out the track so it doesn't have any sharp turns, see #177

--- a/js/view/ControlPointNode.js
+++ b/js/view/ControlPointNode.js
@@ -173,7 +173,10 @@ define( function( require ) {
             model.trackModified( track );
           }
           track.bumpAboveGround();
-          track.bumpAsideWindow();
+
+          //Zhilin added
+          track.bumpAsideLeftWindow();
+          track.bumpAsideRightWindow();
           track.dragging = false;
 
           // Show the 'control point editing' ui, but only if the user didn't drag the control point.

--- a/js/view/TrackDragHandler.js
+++ b/js/view/TrackDragHandler.js
@@ -237,7 +237,10 @@ define( function( require ) {
         }
 
         track.bumpAboveGround();
-        track.bumpAsideWindow();
+        //Zhilin addded
+        track.bumpAsideLeftWindow();
+        track.bumpAsideRightWindow();
+
         track.dragging = false;
         track.dropped = true;
 


### PR DESCRIPTION
Debugging roller coaster simulator:

Log by Zhilin:

Issue 6: There are times when the output values do not fit into the boxes, like for the value for acceleration here.
--Change the position of buttons “reset” and “Delete Track” to the right.
--Make the panels “Inputs”, “Forces”, and “Speed” larger in width.


Issue 3: Roller coaster car is too large relative to the track. Want the car size changes with the mass more obviously.
--Make the car change more obviously

Issue 1:  the car and top of the initial drop are not visible on the screen (you can see it if the screen size is minimized, but seems problematic.)
Issue 2:  Relatedly, at one point, I clicked on “delete track” I was able to delete several parts of the track. But as you can see, I was not able to delete the initial drop, which is almost completely off the screen (see in screenshot on right).
--Track.js: added two methods: getLowestX() and bumpAsideLeftWindow(), which ensures the track not going out of the left limit of window
--SimulationModel.js: call newTrack.bumpAsideLeftWindow() twice
--ControlPointNode.js: call track.bumpAsideLeftWindow()
--TrackDragHandler.js: call track.bumpAsideLeftWindow()

New Issue: What if the track goes out of the right limit?
--Track.js: added two methods: getHighestX() and bumpAsideRightWindow(), which ensures the track not going out of the right limit of window
--SimulationModel.js: call newTrack.bumpAsideRightWindow() twice
--ControlPointNode.js: call track.bumpAsideRightWindow()
--TrackDragHandler.js: call track.bumpAsideRightWindow()